### PR TITLE
Fix small error in setting the output filename

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,8 +50,8 @@ def convert(source_path, target_path, images):
   for image in images:
     temp_image = Image.open(os.path.join(source_path, image))
     with Image.open(os.path.join(source_path, image)) as temp_image:
-      print("Converting {} out of {}  {}".format(count,total_count,image))
-      temp_image.save(os.path.join(target_path, image.strip(image.split(".")[-1]) +"avif"),"avif")
+      print("Converting {} out of {}  {}".format(count, total_count, image))
+      temp_image.save(os.path.join(target_path, image[:-len(image.split(".")[-1])] + "avif"),"avif")
     count += 1
 
 def copy_files(source_path,target_path,compressed_images,others):


### PR DESCRIPTION
The previous method of using strip() had potential of removing letters from the beginning of a filename.  For example, the input file of "p1020440_89.8616_o.jpg" would create an output file named "1020440_89.8616_o.avif" as strip() would match and remove the inital p (based on the search pattern "jpg").

Instead, let's just remove letters based on the length of the file extension.